### PR TITLE
Bad substitutions / update shellfire core

### DIFF
--- a/bish-bosh
+++ b/bish-bosh
@@ -11,7 +11,7 @@ _program()
 	bishbosh_adjustReadLatencyIfNecessary()
 	{
 		if core_variable_isSet BASH_VERSINFO; then
-			if [ ${BASH_VERSINFO[0]} -eq 3 ]; then
+			if [ ${BASH_VERSINFO:0:1} -eq 3 ]; then
 				if [ $bishbosh_readLatency -lt 1000 ]; then
 					core_message WARN "bash 3 does not support fractional read latency (we're forcing bishbosh_readLatency to 1000 ms) [discovered on Mac OS X when run as default sh]"
 					bishbosh_readLatency=1000

--- a/lib/shellfire/bishbosh/backend/socat.functions
+++ b/lib/shellfire/bishbosh/backend/socat.functions
@@ -117,7 +117,7 @@ bishbosh_backend_socat_start()
 						core_exitError $core_commandLine_exitCode_CONFIG "The backend socat does not support the '$bishbosh_proxyKind' proxy kind when the tunnel is 'tls'"
 					fi
 					
-					addressKind="${$bishbosh_proxyKind}:${bishbosh_proxyAddress}:${bishbosh_server}:${bishbosh_port}"
+					addressKind="${bishbosh_proxyKind}:${bishbosh_proxyAddress}:${bishbosh_server}:${bishbosh_port}"
 					if core_variable_isSet bishbosh_proxyPort; then
 						addressKind="${addressKind},socksport=${bishbosh_proxyPort}"
 					fi
@@ -213,7 +213,7 @@ bishbosh_backend_socat_start()
 		
 			esac
 			
-			local binding
+			local binding=''
 			if core_variable_isSet bishbosh_sourceAddress; then
 				binding=",bind=$bishbosh_sourceAddress"
 				if core_variable_isSet bishbosh_sourcePort; then
@@ -223,11 +223,9 @@ bishbosh_backend_socat_start()
 				binding=",sourceport=${bishbosh_sourcePort}"
 			fi
 			
-			local connectTimeout
+			local connectTimeout=''
 			if [ $bishbosh_connectTimeout -ne 0 ]; then
 				connectTimeout=",connect-timeout=${bishbosh_connectTimeout}"
-			else
-				connectTimeout=''
 			fi
 			
 			# keepidle, keepintvl, keepcnt, linger2, mss, mss-late, syncnt


### PR DESCRIPTION
These changes were required to get bish-bosh running on a Wink hub (`BusyBox v1.24.2 (2017-03-20 20:34:40 UTC) multi-call binary.`) Thanks to [theses commits](https://github.com/shellfire-dev/core/compare/ce3997b519c8cd9db95c18b9f28060bacf32767c...9dd4b0694d37ddcc853712855bf62b5fec7d0dbe) in shellfire-core, I believe this also fixes #6 and #7.