### PR TITLE
Fixed empty topicName local variable

### DIFF
--- a/lib/shellfire/bishbosh/connection/read/controlpacket/PUBLISH.functions
+++ b/lib/shellfire/bishbosh/connection/read/controlpacket/PUBLISH.functions
@@ -103,7 +103,7 @@ _bishbosh_connection_read_PUBLISH()
 		remainingTopicLength=$((remainingTopicLength-1))
 	done
 	
-	local topicName="$(<"$temporaryTheirPacketIdentifierFolderPath"/topic-name)"
+	local topicName="$(cat "$temporaryTheirPacketIdentifierFolderPath"/topic-name)"
 	
 	local packetIdentifier
 	local messageLength


### PR DESCRIPTION
As [mentioned by @arnaudlds in issue 10](https://github.com/raphaelcohn/bish-bosh/issues/10), $topicName local variable was returning an empty value in PUBLISH functions.
I couldn't find any way to fix it without using the `cat` binary.

